### PR TITLE
feat: support rule precedence

### DIFF
--- a/tests/fixtures/dir1/Zfile
+++ b/tests/fixtures/dir1/Zfile
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo file: $XF_FILE

--- a/tests/fixtures/dir1/config3
+++ b/tests/fixtures/dir1/config3
@@ -1,0 +1,1 @@
+Zfile:bash $file

--- a/tests/unix_tests.rs
+++ b/tests/unix_tests.rs
@@ -77,3 +77,19 @@ args: a b
         "<dir>"
     );
 }
+
+#[test]
+fn rule_precedence() {
+    let assert = xf()
+        .current_dir("tests/fixtures/dir1")
+        .env(env_config_path(), &fixtures_dir(&["dir1", "config3"]))
+        .assert()
+        .success();
+    assert_output!(
+        assert,
+        r#"file: <dir>/dir1/Zfile
+"#,
+        &fixtures_dir(&[]),
+        "<dir>"
+    );
+}


### PR DESCRIPTION
The more front rules are matched earlier

```
Zfile:bash -c "echo Zfile"
Afile:bash -c "echo Afile"
```

if exsisted `Zfile` and `Afile` in the directory, `Zfile` will get matched, and  `bash -c "echo Zfile"` will be executed.